### PR TITLE
Problem: there are no GoCZMQ cookbook examples

### DIFF
--- a/goczmq/README.md
+++ b/goczmq/README.md
@@ -1,0 +1,5 @@
+= GoCZMQ
+
+This directory contains cookbook examples for the [GoCZMQ](http://github.com/zeromq/goczmq) Go bindings for [CZMQ](http://github.com/zeromq/czmq).
+
+== Included Recipes


### PR DESCRIPTION
Solution: Add a directory and a minimal README so that we can get started.
